### PR TITLE
Fix undefined variables bug when no features selected (ninmax <= 0)

### DIFF
--- a/glmnet/paths/fastnet.py
+++ b/glmnet/paths/fastnet.py
@@ -296,6 +296,11 @@ class FastNetMixin(GLMNet): # base class for C++ path methods
             coefs = np.zeros((nfits, n_features))
             coefs[:, active_seq] = unsort_coefs[:, :len(active_seq)]
             intercepts = _fit['a0'][:nfits]
+        else:
+            # No features selected; return zeros
+            coefs = np.zeros((nfits, n_features))
+            intercepts = _fit['a0'][:nfits]
+            df = np.zeros(nfits, dtype=int)
 
         return {'coefs':coefs,
                 'intercepts':intercepts,


### PR DESCRIPTION
Ran into this when testing a very wide regularization path:

When ninmax <= 0 (no features selected due to high penalty, all features ineligible, or numerical issues), the variables coefs, intercepts, and df were undefined but referenced in the return statement, causing an error.

Added else clause to initialize these variables with zeros when ninmax <= 0, ensuring the method returns valid results in all cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)